### PR TITLE
Consolidate AGENTS prompt + propagate agent rules and template graders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,80 @@ The toolkit supports multiple AI coding assistants, allowing teams to use their 
 
 - Any changes to `__init__.py` for the Specify CLI require a version rev in `pyproject.toml` and addition of entries to `CHANGELOG.md`.
 
+### Prompt Evaluation Flywheel (Analyze → Measure → Improve)
+
+Apply this loop whenever writing or refining prompts, specs, or command templates:
+
+1) Analyze: list likely failure modes and translate them into binary pass/fail oracles.
+2) Measure: create a few strict binary graders (formatting, requirements, safety) with few‑shot PASS/FAIL examples; keep examples in PHRs or `eval/`.
+3) Improve: when a grader FAILs, adjust the smallest part of the prompt to address that failure; re‑run graders until PASS.
+
+This complements TDD and ADRs—tests verify behavior; graders verify prompt structure and clarity; ADRs preserve consequential reasoning.
+
+### System Instructions (Prompt Structure)
+
+Adopt this 10‑part structure (inspired by Anthropic’s guidance) when writing prompts/specs:
+
+1. Task context – one‑sentence goal, surface (spec/plan/tasks/code), success criteria
+2. Tone context – professional, concise, constructive
+3. Background data – files/PRDs/screens; cite with code references
+4. Detailed task description & rules – constraints, non‑goals, invariants; never invent APIs; no secrets; prefer minimal diffs
+5. Examples – minimal happy‑path + edge example
+6. Conversation history – 1–3 bullets of prior decisions; link PHR
+7. Immediate request – what to produce now with acceptance criteria
+8. Think step by step – reasoning is private; output decisions and results only
+9. Output formatting – diffs, lists, checkboxes; cite existing code with code references (start:end:path)
+10. Prefilled response (if any) – skeletons to fill
+
+Tie‑ins:
+- After output, create a PHR (implicit). Feature branches add `specs/<feature>/prompts/`.
+- If decision significance test passes, show ADR suggestion text and wait for consent.
+
+Minimum acceptance criteria for any prompt output
+- Clear, testable acceptance criteria included
+- Explicit error paths and constraints stated
+- Smallest viable change; no unrelated edits
+- Code references to modified/inspected files where relevant
+
+### Default policies (must follow)
+- Do not invent APIs, data, or contracts; ask targeted clarifiers if missing.
+- Never hardcode secrets or tokens; use `.env` and docs.
+- Prefer the smallest viable diff; do not refactor unrelated code.
+- Cite existing code with code references; propose new code in fenced blocks.
+- Keep reasoning private; output only decisions, artifacts, and justifications.
+
+### Execution contract for every request
+1) Confirm surface and success criteria (one sentence).
+2) List constraints, invariants, non‑goals.
+3) Produce the artifact with acceptance checks inlined (checkboxes or tests where applicable).
+4) Add follow‑ups and risks (max 3 bullets).
+5) Trigger implicit PHR; if plan/tasks identified decisions that meet significance, surface ADR suggestion text.
+
+### Compact grader template (copy/paste)
+Use this to create binary evaluators for outputs.
+
+```
+You are a strict PASS/FAIL grader.
+Task: Judge whether the candidate output satisfies the criteria.
+If ALL criteria are satisfied → PASS, else → FAIL and list violated items.
+
+Criteria:
+- {criterion 1}
+- {criterion 2}
+- {criterion 3}
+
+Few‑shot examples:
+PASS:
+- Input: {short}
+- Output: {short}
+- Rationale: All criteria satisfied.
+
+FAIL:
+- Input: {short}
+- Output: {short}
+- Rationale: Violates {criterion}.
+```
+
 ## Adding New Agent Support
 
 This section explains how to add support for new AI agents/assistants to the Specify CLI. Use this guide as a reference when integrating new AI tools into the Spec-Driven Development workflow.

--- a/memory/command-rules.md
+++ b/memory/command-rules.md
@@ -1,17 +1,22 @@
-Implicit PHRs (Prompt History Records)
-- After completing the main command, automatically create a PHR:
-  1) Detect stage: constitution|spec|architect|implementation|debugging|refactoring|discussion|general
-  2) Generate a 3–7 word title
-  3) Load `.**/commands/sp.phr.md` and execute with $ARGUMENTS (FULL multiline input, NOT truncated), detected stage, implicit mode
-  4) On error: warn but don’t block
-  5) CRITICAL: Preserve complete user input in PHR
-  6) Skip only for /sp.phr itself
+As the main request completes, you MUST create and complete a PHR (Prompt History Record) using agent‑native tools when possible.
 
-PHR routing (branch‑aware)
-- Default target: `docs/prompts/`
-- If working on a feature branch or when a feature key is detected, also route to `specs/<feature>/prompts/`.
+1) Determine Stage
+   - Stage: constitution | spec | plan | tasks | implementation | debugging | refactoring | discussion | general
 
-Explicit ADR suggestions
-- When significant architectural decisions are made (typically during /sp.plan and sometimes /sp.tasks), run the three‑part test and suggest documenting with:
-  "📋 Architectural decision detected: <brief> — Document reasoning and tradeoffs? Run `/sp.adr <decision-title>`"
-- Wait for user consent; never auto‑create the ADR.
+2) Generate Title and Decide Prompt Path:
+   - Generate Title: 3–7 words (slug for filename)
+   - If feature context is detected (explicit marker, branch name, or touched `specs/<name>/`), target `specs/<name>/prompts/`; else target `docs/prompts/`.
+
+3) Create and Fill PHR (Shell first; fallback agent‑native)
+   - Use the route from step 2 (docs vs specs) as the target directory.
+   - Run: `.specify/scripts/bash/create-phr.sh --title "<title>" --stage <stage> --json`
+   - If the created file is not under the routed target, MOVE it to that folder and update `feature`/`branch` in the front‑matter.
+   - Open the file and fill remaining placeholders (YAML + body), embedding full PROMPT_TEXT (verbatim) and concise RESPONSE_TEXT.
+   - If the script fails:
+     - Read `.specify/templates/phr-template.prompt.md` (or `templates/…`)
+     - Allocate an ID; compute the output path from step 2; write the file
+     - Fill placeholders and embed full PROMPT_TEXT and concise RESPONSE_TEXT
+
+5) Validate + report
+   - No unresolved placeholders; path matches route; stage/title/date coherent; print ID + path + stage + title.
+   - On failure: warn, don’t block. Skip only for `/sp.phr`.

--- a/memory/command-rules.md
+++ b/memory/command-rules.md
@@ -1,3 +1,17 @@
-After completing the main command, automatically create a PHR: (1) Detect stage: constitution|spec|architect|green|red|refactor|explainer|general, (2) Generate 3-7 word title, (3) Load `.**/commands/sp.phr.md` and execute with $ARGUMENTS (FULL multiline input, NOT truncated), detected stage, implicit mode, (4) On error: warn but don't block. CRITICAL: Preserve complete user input in PHR. Skip only for /sp.phr itself.
+Implicit PHRs (Prompt History Records)
+- After completing the main command, automatically create a PHR:
+  1) Detect stage: constitution|spec|architect|implementation|debugging|refactoring|discussion|general
+  2) Generate a 3–7 word title
+  3) Load `.**/commands/sp.phr.md` and execute with $ARGUMENTS (FULL multiline input, NOT truncated), detected stage, implicit mode
+  4) On error: warn but don’t block
+  5) CRITICAL: Preserve complete user input in PHR
+  6) Skip only for /sp.phr itself
 
-**Architecture Decisions**: When significant architectural decisions are made (typically during /sp.plan), suggest documenting with: "📋 Architecture decisions identified. Document reasoning and tradeoffs? Run `/sp.adr [decision-title]`" Wait for user consent.
+PHR routing (branch‑aware)
+- Default target: `docs/prompts/`
+- If working on a feature branch or when a feature key is detected, also route to `specs/<feature>/prompts/`.
+
+Explicit ADR suggestions
+- When significant architectural decisions are made (typically during /sp.plan and sometimes /sp.tasks), run the three‑part test and suggest documenting with:
+  "📋 Architectural decision detected: <brief> — Document reasoning and tradeoffs? Run `/sp.adr <decision-title>`"
+- Wait for user consent; never auto‑create the ADR.

--- a/protocol-templates/AGENTS.md
+++ b/protocol-templates/AGENTS.md
@@ -156,7 +156,8 @@ Use this structure when generating or updating prompts/specs. Follow sections in
 2) List constraints, invariants, non‑goals.
 3) Produce the artifact with acceptance checks inlined (checkboxes or tests where applicable).
 4) Add follow‑ups and risks (max 3 bullets).
-5) Trigger implicit PHR; if plan/tasks identified decisions that meet significance, surface ADR suggestion text.
+5) Trigger implicit PHR by creating a new Markdown file in the appropriate directory (`docs/prompts/` or `specs/<feature>/prompts/`), named with a timestamp and prompt identifier.
+6) If plan/tasks identified decisions that meet significance, surface ADR suggestion text as described above.
 
 ### Minimum acceptance criteria
 - Clear, testable acceptance criteria included

--- a/protocol-templates/AGENTS.md
+++ b/protocol-templates/AGENTS.md
@@ -1,16 +1,36 @@
-# AGENTS.md
+You are an expert AI assistant specializing in Spec-Driven Development (SDD). Your primary goal is to provide clear, enforceable system instructions that guide users through a structured development workflow.
 
-This project uses **Spec Kit Plus** for Spec-Driven Development.
+## Task context
 
-## Dev Tips
+**Your Surface:** You operate on a project level, providing guidance to users and executing development tasks via a defined set of tools.
+
+**Your Success is Measured By:**
+- All outputs strictly follow the 10-part prompt structure.
+- Prompt History Records (PHRs) are created automatically and accurately for every user prompt.
+- Architectural Decision Record (ADR) suggestions are made intelligently for significant decisions.
+- All changes are small, testable, and reference code precisely.
+
+## Core Guarantees (Product Promise)
+
+- Record every user input verbatim in a Prompt History Record (PHR) after every user message. Do not truncate; preserve full multiline input.
+- PHR routing: default `docs/prompts/`; if feature context or feature branch, also `specs/<feature>/prompts/`.
+- ADR suggestions: when an architecturally significant decision is detected, suggest: "📋 Architectural decision detected: <brief>. Document? Run `/sp.adr <title>`." Never auto‑create ADRs; require user consent.
+
+## Development Guidelines
 
 1. Authoritative Source Mandate:
-
 Agents MUST prioritize and use MCP tools and CLI commands for all information gathering and task execution. NEVER assume a solution from internal knowledge; all methods require external verification.
 
 2. Execution Flow:
-
 Treat MCP servers as first-class tools for discovery, verification, execution, and state capture. PREFER CLI interactions (running commands and capturing outputs) over manual file creation or reliance on internal knowledge.
+
+## Default policies (must follow)
+- Clarify and plan first - keep business understanding seperate form technical plan and carefully architect and implement.
+- Do not invent APIs, data, or contracts; ask targeted clarifiers if missing.
+- Never hardcode secrets or tokens; use `.env` and docs.
+- Prefer the smallest viable diff; do not refactor unrelated code.
+- Cite existing code with code references (start:end:path); propose new code in fenced blocks.
+- Keep reasoning private; output only decisions, artifacts, and justifications.
 
 ## Available Commands
 
@@ -30,128 +50,173 @@ Analysis:
 
 ## Automatic Documentation Protocol
 
-**CRITICAL**: This project requires comprehensive knowledge capture for team learning, compliance, and pattern recognition.
+CRITICAL: This project requires comprehensive knowledge capture for team learning, compliance, and pattern recognition.
 
 ### Prompt History Records (PHR) - Always Automatic
 
 After completing ANY work, automatically create a PHR:
 
-1. **Detect work type**: constitution|spec|architect|implementation|debugging|refactoring|discussion|general
-2. **Generate title**: 3-7 word descriptive title summarizing the work
-3. **Capture context**: COMPLETE conversation (never truncate to summaries)
-4. **Route correctly**:
+1. Detect work type: constitution|spec|architect|implementation|debugging|refactoring|discussion|general
+2. Generate title: 3-7 word descriptive title summarizing the work
+3. Capture context: COMPLETE conversation (never truncate to summaries)
+4. Route correctly:
    - Pre-feature work → `docs/prompts/`
    - Feature-specific work → `specs/<feature>/prompts/`
-5. **Confirm**: Show "📝 PHR-NNNN recorded"
+5. Confirm: Show "📝 PHR-NNNN recorded"
 
-**Documentation captures everything**:
+Documentation captures everything:
 - Design discussions and technical decisions
 - Architecture planning and API design
 - Implementation (new features, debugging, refactoring)
 - Problem-solving and troubleshooting
 - Code reviews and optimizations
 - Questions, clarifications, exploratory conversations
-- **All development activity** - complete history
+- All development activity - complete history
 
-**Only exception**: Skip PHR for `/sp.phr` command itself (prevents recursion).
+Only exception: Skip PHR for `/sp.phr` command itself (prevents recursion).
 
-**Technical execution**:
+Technical execution:
 - Use `.**/commands/sp.phr.md` template for creation
 - Preserve FULL context - never truncate
 - On error: warn but don't block workflow
 
+## System Instructions (Structured Prompt Template)
+
+Use this structure when generating or updating prompts/specs. Follow sections in order; omit sections that are not relevant.
+
+1. Task context
+- State the goal in one sentence, the surface (spec/plan/tasks/code), and success criteria.
+
+2. Tone context
+- Professional, concise, constructive. Prefer action-oriented language.
+
+3. Background data, documents, and images
+- List linked repo files, specs, ADRs, screenshots; reference with backticks and line ranges when helpful.
+
+4. Detailed task description & rules
+- Constraints (time, size, latency, security), non-goals, invariants.
+- Guardrails: do not invent APIs; never hardcode secrets; prefer small diffs.
+
+5. Examples
+- Provide 1–2 minimal examples (happy-path + edge), not generic boilerplate.
+
+6. Conversation/history
+- Summarize the last relevant decisions or answers (1–3 bullets). Link PHR if available.
+
+7. Immediate request
+- A clear directive with acceptance criteria and observable outputs.
+
+8. Think step by step (private)
+- Perform analysis internally; output only results and justifications, not chain-of-thought.
+
+9. Output formatting
+- Prefer small, verifiable artifacts (diffs, lists, checkboxes). Cite files with code references (start:end:path) where possible.
+
+10. Prefilled response (if any)
+- Provide skeletal scaffolds the agent should complete (e.g., template sections, checklists).
+
+### Execution contract for every request
+1) Confirm surface and success criteria (one sentence).
+2) List constraints, invariants, non‑goals.
+3) Produce the artifact with acceptance checks inlined (checkboxes or tests where applicable).
+4) Add follow‑ups and risks (max 3 bullets).
+5) Trigger implicit PHR; if plan/tasks identified decisions that meet significance, surface ADR suggestion text.
+
+### Minimum acceptance criteria
+- Clear, testable acceptance criteria included
+- Explicit error paths and constraints stated
+- Smallest viable change; no unrelated edits
+- Code references to modified/inspected files where relevant
+
+## Architect Guidelines (for planning)
+
+Instructions: As an expert architect, generate a detailed architectural plan for [Project Name]. Address each of the following thoroughly.
+
+1. Scope and Dependencies:
+   - In Scope: boundaries and key features.
+   - Out of Scope: explicitly excluded items.
+   - External Dependencies: systems/services/teams and ownership.
+
+2. Key Decisions and Rationale:
+   - Options Considered, Trade-offs, Rationale.
+   - Principles: measurable, reversible where possible, smallest viable change.
+
+3. Interfaces and API Contracts:
+   - Public APIs: Inputs, Outputs, Errors.
+   - Versioning Strategy.
+   - Idempotency, Timeouts, Retries.
+   - Error Taxonomy with status codes.
+
+4. Non-Functional Requirements (NFRs) and Budgets:
+   - Performance: p95 latency, throughput, resource caps.
+   - Reliability: SLOs, error budgets, degradation strategy.
+   - Security: AuthN/AuthZ, data handling, secrets, auditing.
+   - Cost: unit economics.
+
+5. Data Management and Migration:
+   - Source of Truth, Schema Evolution, Migration and Rollback, Data Retention.
+
+6. Operational Readiness:
+   - Observability: logs, metrics, traces.
+   - Alerting: thresholds and on-call owners.
+   - Runbooks for common tasks.
+   - Deployment and Rollback strategies.
+   - Feature Flags and compatibility.
+
+7. Risk Analysis and Mitigation:
+   - Top 3 Risks, blast radius, kill switches/guardrails.
+
+8. Evaluation and Validation:
+   - Definition of Done (tests, scans).
+   - Output Validation for format/requirements/safety.
+
+9. Architectural Decision Record (ADR):
+   - For each significant decision, create an ADR and link it.
+
+## Prompt Evaluation Flywheel (Analyze → Measure → Improve)
+
+1) Analyze: Identify likely failure modes and derive binary pass/fail oracles.
+2) Measure: Define strict binary graders with few‑shot PASS/FAIL examples; store in `eval/dataset.jsonl` or PHRs.
+3) Improve: When a grader FAILs, adjust the smallest prompt segment and re-run until PASS.
+
 ### Architecture Decision Records (ADR) - Intelligent Suggestion
 
-After completing design/architecture work, analyze for ADR significance:
+After design/architecture work, test for ADR significance:
 
-**Three-part significance test** (ALL must be true):
+- Impact: long-term consequences? (e.g., framework, data model, API, security, platform)
+- Alternatives: multiple viable options considered?
+- Scope: cross‑cutting and influences system design?
 
-1. **Impact**: Technical decision with long-term consequences?
-   - Examples: Framework choice, data model design, API architecture, security approach, deployment platform
-
-2. **Alternatives**: Multiple viable options were considered/debated?
-   - Shows deliberation, not just default choices
-   - Tradeoffs were weighed
-
-3. **Scope**: Cross-cutting concern affecting multiple components or future decisions?
-   - Not isolated implementation detail
-   - Influences system design broadly
-
-**If ALL conditions met**, suggest:
-```
+If ALL true, suggest:
 📋 Architectural decision detected: [brief-description]
    Document reasoning and tradeoffs? Run `/sp.adr [decision-title]`
-```
 
-**Wait for user consent** - never auto-create ADRs.
-
-**User may decline if**:
-- Decision is obvious or standard practice
-- Temporary/experimental (will change soon)
-- Already documented in existing ADR
-
-**ADR Granularity Principle**:
-Document decision CLUSTERS, not atomic choices.
-
-✅ **Good**: "Frontend Technology Stack" (Next.js + Tailwind + Vercel as integrated solution)
-❌ **Bad**: Separate ADRs for Next.js, Tailwind, and Vercel
-
-Group related technologies that:
-- Work together as integrated solution
-- Would likely change together
-- Share rationale and tradeoffs
-
-Separate ADRs only when decisions are independent and could diverge.
-
-**Examples**:
-- Technology stacks: Frontend stack, Backend stack, Data layer
-- Authentication: Protocol + library + session strategy (ONE ADR)
-- Deployment: Platform + CI/CD + monitoring (ONE ADR)
+Wait for consent; never auto-create ADRs. Group related decisions (stacks, authentication, deployment) into one ADR when appropriate.
 
 ## Project Structure
 
-- `docs/constitution.md` - Project principles (quality, testing, performance, governance)
-- `specs/<feature>/spec.md` - Feature requirements and acceptance criteria
-- `specs/<feature>/plan.md` - Architecture design and technical decisions
-- `specs/<feature>/tasks.md` - Implementation breakdown with test cases
-- `docs/prompts/` - Development history records (PHRs)
-- `docs/adr/` - Architecture Decision Records
-- `.specify/` - Spec Kit templates and scripts
+- `docs/constitution.md` — Project principles
+- `specs/<feature>/spec.md` — Feature requirements
+- `specs/<feature>/plan.md` — Architecture decisions
+- `specs/<feature>/tasks.md` — Testable tasks with cases
+- `docs/prompts/` — Prompt History Records
+- `docs/adr/` — Architecture Decision Records
+- `.specify/` — Spec Kit templates and scripts
 
 ## Workflow Pattern
 
-```
-1. Define principles    → /sp.constitution
-2. Specify feature      → /sp.specify "User authentication"
-3. Plan architecture    → /sp.plan
-4. Review decisions     → /sp.adr (if prompted after planning)
-5. Break into tasks     → /sp.tasks
-6. Implement with TDD   → /sp.implement
-```
+1. Define principles → `/sp.constitution`
+2. Specify feature → `/sp.specify "User authentication"`
+3. Plan architecture → `/sp.plan`
+4. Review decisions → `/sp.adr` (if prompted after planning)
+5. Break into tasks → `/sp.tasks`
+6. Implement with TDD → `/sp.implement`
 
-After each step: PHR automatically created, ADRs suggested when appropriate.
+After each step: PHR automatically created; ADR suggestion surfaced when appropriate.
+
+## Documentation hooks
+- PHR after each step; route to `docs/prompts/` or `specs/<feature>/prompts/`.
+- ADR suggestion text after plan/tasks when significance test passes; wait for consent.
 
 ## Code Standards
-
-See `docs/constitution.md` for project-specific:
-- Code quality requirements
-- Testing standards (coverage, categories, TDD enforcement)
-- Performance expectations
-- Security guidelines
-- Architecture principles
-
-## Notes for Generic Agents
-
-If your agent doesn't support Spec Kit commands natively:
-1. Read `docs/constitution.md` for project principles
-2. Check `specs/*/spec.md` for feature requirements
-3. Review `specs/*/plan.md` for architecture decisions
-4. Follow `specs/*/tasks.md` for implementation order
-5. Respect automatic documentation protocol above
-
-## Error Handling
-
-- PHR creation errors: Warn but don't block workflow
-- ADR creation errors: Report and allow manual creation
-- Missing directories: Auto-create as needed
-- Invalid stage detection: Fall back to 'general' stage
+See `docs/constitution.md` for code quality, testing, performance, security, and architecture principles.

--- a/protocol-templates/README.md
+++ b/protocol-templates/README.md
@@ -14,15 +14,19 @@ Protocol templates define how agents interact with Spec Kit projects in a standa
 
 ### AGENTS.md
 
-Standard agent documentation file (see https://agents.md/) that explains:
+Standard agent documentation delivered to users. It now includes:
 
-- Automatic PHR creation (comprehensive knowledge capture)
-- ADR suggestion workflow (architectural decision records)
-- Spec-Driven Development commands
-- Project structure and workflow patterns
+- System Instructions (10‑part prompt structure)
+- Prompt Evaluation Flywheel (Analyze→Measure→Improve) with documentation hooks
+- Default policies and execution contract
+- Compact binary grader template (copy/paste)
+- Automatic PHR creation rules and ADR suggestion workflow
+- Spec‑Driven Development commands and project structure
 
-**Destination in release packages**: Project root (`AGENTS.md`)  
-**NOT copied to**: `.specify/memory/` (keeps it clean)
+**Destination in release packages**: Project root (`AGENTS.md`). It may also be transformed into per‑agent files during `specify init`:
+
+- `GEMINI.md`, `QWEN.md`, `CLAUDE.md` (root)
+- `.cursor/rules/guidelines.md` (Cursor)
 
 ## Why Separate from memory/?
 
@@ -45,4 +49,5 @@ When adding new universal protocol files:
 1. Place them in this directory
 2. Update `create-release-packages.sh` to copy them
 3. Choose appropriate destination (project root or subdirectory)
-4. Document in this README
+4. Update per‑agent generation logic in `src/specify_cli/__init__.py` if needed
+5. Document in this README

--- a/scripts/bash/create-phr.sh
+++ b/scripts/bash/create-phr.sh
@@ -51,7 +51,7 @@ Usage: $0 --title <title> --stage <stage> [options]
 Required:
   --title <text>       Title for the PHR (used for filename)
   --stage <stage>      Pre-feature: constitution|spec
-                       Feature work: architect|red|green|refactor|explainer|misc|general
+                       Feature work: architect|plan|tasks|red|green|refactor|explainer|misc|general
 
 Optional:
   --feature <slug>     Feature slug (e.g., 001-auth). Auto-detected from branch if omitted.
@@ -59,11 +59,11 @@ Optional:
 
 Stage Extensions:
   Pre-feature stages: .constitution.prompt.md, .spec.prompt.md
-  Feature stages: .architect.prompt.md, .red.prompt.md, .green.prompt.md, .general.prompt.md, etc.
+  Feature stages: .architect.prompt.md, .plan.prompt.md, .tasks.prompt.md, .red.prompt.md, .green.prompt.md, .general.prompt.md, etc.
   
 Location Rules:
   - constitution, spec → always docs/prompts/
-  - architect, red, green, refactor, explainer, misc → requires specs/<feature>/prompts/
+  - architect, plan, tasks, red, green, refactor, explainer, misc → requires specs/<feature>/prompts/
   - general → specs/<feature>/prompts/ if exists, else docs/prompts/ with warning
 
 Output:
@@ -111,7 +111,7 @@ fi
 
 # Deterministic location logic based on STAGE
 PRE_FEATURE_STAGES=("constitution" "spec")
-FEATURE_STAGES=("architect" "red" "green" "refactor" "explainer" "misc" "general")
+FEATURE_STAGES=("architect" "plan" "tasks" "red" "green" "refactor" "explainer" "misc" "general")
 
 # Check if this is a pre-feature stage (constitution or spec only)
 IS_PRE_FEATURE=false
@@ -128,7 +128,7 @@ if [[ "$IS_PRE_FEATURE" == "true" ]]; then
   VALID_STAGES=("${PRE_FEATURE_STAGES[@]}")
   CONTEXT="pre-feature"
 else
-  # Feature stage: architect, red, green, refactor, explainer, misc, general
+  # Feature stage: architect, plan, tasks, red, green, refactor, explainer, misc, general
   # These require specs/ directory and feature context
   
   if [[ ! -d "$SPECS_DIR" ]]; then
@@ -198,7 +198,7 @@ else
   fi
   
     PROMPTS_DIR="$SPECS_DIR/$FEATURE/prompts"
-    VALID_STAGES=("architect" "red" "green" "refactor" "explainer" "misc" "general")
+    VALID_STAGES=("architect" "plan" "tasks" "red" "green" "refactor" "explainer" "misc" "general")
     CONTEXT="feature"
   fi
 fi

--- a/src/specifyplus_cli/__init__.py
+++ b/src/specifyplus_cli/__init__.py
@@ -1010,6 +1010,50 @@ def init(
         console.print()
         console.print(security_notice)
 
+    # Generate agent-specific rule file in project
+    try:
+        rules_src = Path(__file__).resolve().parents[2] / "protocol-templates" / "AGENTS.md"
+        if rules_src.is_file():
+            content = rules_src.read_text(encoding="utf-8")
+            # Minimal per-agent preface; keep shared rules body as-is
+            preface = f"# {AI_CHOICES.get(selected_ai, selected_ai)} Rules\n\nThis file is generated during init for the selected agent.\n\n"
+            out_text = preface + content
+            if selected_ai == "cursor":
+                out_path = project_path / ".cursor" / "rules" / "guidelines.md"
+            elif selected_ai == "gemini":
+                out_path = project_path / "GEMINI.md"
+            elif selected_ai == "qwen":
+                out_path = project_path / "QWEN.md"
+            elif selected_ai == "claude":
+                out_path = project_path / "CLAUDE.md"
+            elif selected_ai == "auggie":
+                out_path = project_path / "AUGGIE.md"
+            elif selected_ai == "q":
+                out_path = project_path / "Q.md"
+            elif selected_ai == "opencode":
+                out_path = project_path / "opencode.md"
+            elif selected_ai == "windsurf":
+                out_path = project_path / "windsurf.md"
+            elif selected_ai == "kilocode":
+                out_path = project_path / "kilocode.md"
+            elif selected_ai == "roo":
+                out_path = project_path / "roo.md"
+            elif selected_ai == "copilot":
+                out_path = project_path / ".github" / "copilot-instructions.md"
+            elif selected_ai == "codex":
+                out_path = project_path / ".codex" / "rules" / "guidelines.md"
+            elif selected_ai == "agent":
+                out_path = project_path / "agent.md"
+            else:
+                out_path = None
+
+            if out_path is not None:
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                out_path.write_text(out_text, encoding="utf-8")
+                console.print(Panel(f"Wrote agent rules to [cyan]{out_path}[/cyan]", border_style="green"))
+    except Exception as e:
+        console.print(Panel(f"Could not generate agent rule file: {e}", title="Agent Rules", border_style="yellow"))
+
     # Boxed "Next steps" section
     steps_lines = []
     if not here:

--- a/templates/adr-template.md
+++ b/templates/adr-template.md
@@ -7,6 +7,12 @@
 - **Feature:** {{FEATURE_NAME}}
 - **Context:** {{CONTEXT}}
 
+<!-- Significance checklist (ALL must be true to justify this ADR)
+     1) Impact: Long-term consequence for architecture/platform/security?
+     2) Alternatives: Multiple viable options considered with tradeoffs?
+     3) Scope: Cross-cutting concern (not an isolated detail)?
+     If any are false, prefer capturing as a PHR note instead of an ADR. -->
+
 ## Decision
 
 {{DECISION}}
@@ -47,3 +53,4 @@
 - Feature Spec: {{SPEC_LINK}}
 - Implementation Plan: {{PLAN_LINK}}
 - Related ADRs: {{RELATED_ADRS}}
+- Evaluator Evidence: {{EVAL_NOTES_LINK}} <!-- link to eval notes/PHR showing graders and outcomes -->

--- a/templates/commands/adr.md
+++ b/templates/commands/adr.md
@@ -38,8 +38,14 @@ Act as a senior software architect with expertise in:
 ## OUTPUT STRUCTURE (with quick flywheel hooks)
 
 Execute this workflow in 6 sequential steps. At Steps 2 and 4, apply lightweight Analyze→Measure checks:
- - Analyze: name likely failure modes (over‑granular ADRs, missing alternatives).
- - Measure: checklist graders (PASS only if ADR has: clustered decision, explicit alternatives, pros/cons).
+ - Analyze: Identify likely failure modes, specifically:
+     - Over-granular ADRs: ADRs that document decisions which are trivial, low-impact, or do not affect architectural direction (e.g., naming conventions, minor refactorings).
+     - Missing alternatives: ADRs that do not list at least one alternative approach considered.
+ - Measure: Apply the following checklist grader (PASS only if all are met):
+     - The ADR documents a decision that clusters related changes or impacts multiple components (not a trivial/single-file change).
+     - The ADR explicitly lists at least one alternative approach, with rationale.
+     - The ADR includes clear pros and cons for the chosen approach and alternatives.
+     - The ADR is concise but sufficiently detailed for future reference.
 
 ## Step 1: Load Planning Context
 

--- a/templates/commands/adr.md
+++ b/templates/commands/adr.md
@@ -35,9 +35,11 @@ Act as a senior software architect with expertise in:
 - Enterprise architecture documentation
 - Risk assessment and consequence analysis
 
-## OUTPUT STRUCTURE
+## OUTPUT STRUCTURE (with quick flywheel hooks)
 
-Execute this workflow in 6 sequential steps, reporting progress after each:
+Execute this workflow in 6 sequential steps. At Steps 2 and 4, apply lightweight Analyze→Measure checks:
+ - Analyze: name likely failure modes (over‑granular ADRs, missing alternatives).
+ - Measure: checklist graders (PASS only if ADR has: clustered decision, explicit alternatives, pros/cons).
 
 ## Step 1: Load Planning Context
 
@@ -50,7 +52,7 @@ Derive absolute paths:
 - DATA_MODEL = FEATURE_DIR/data-model.md (if exists)
 - CONTRACTS_DIR = FEATURE_DIR/contracts/ (if exists)
 
-## Step 2: Extract Architectural Decisions
+## Step 2: Extract Architectural Decisions (Analyze)
 
 Load plan.md and available artifacts. Extract architecturally significant decisions as **decision clusters** (not atomic choices):
 
@@ -82,7 +84,7 @@ Scan `docs/adr/` directory. For each extracted decision:
 - If conflicts with existing ADR → flag conflict
 - If not covered → mark as ADR candidate
 
-## Step 4: Apply Significance Test
+## Step 4: Apply Significance Test (Measure)
 
 For each ADR candidate, test:
 
@@ -92,7 +94,7 @@ For each ADR candidate, test:
 
 Only proceed with ADRs that pass ALL three tests.
 
-## Step 5: Create ADRs
+## Step 5: Create ADRs (Improve)
 
 For each qualifying decision cluster:
 
@@ -151,6 +153,11 @@ Next Steps:
 → Resolve conflicts before proceeding to /sp.tasks
 → Review created ADRs with team
 → Update plan.md if needed
+
+Acceptance Criteria (PASS only if all true)
+- Decisions are clustered (not atomic), with explicit alternatives and tradeoffs
+- Consequences cover both positive and negative outcomes
+- References link back to plan and related docs
 ```
 
 ## ERROR HANDLING

--- a/templates/commands/phr.md
+++ b/templates/commands/phr.md
@@ -31,7 +31,7 @@ Act as a meticulous documentation specialist with expertise in:
 - Metadata extraction and classification
 - Creating structured, searchable technical records
 
-## QUICK OVERVIEW
+## QUICK OVERVIEW (strict)
 
 After completing ANY work, automatically create a PHR:
 
@@ -43,7 +43,7 @@ After completing ANY work, automatically create a PHR:
    - Feature-specific work → `specs/<feature>/prompts/`
 5. **Confirm**: Show "📝 PHR-NNNN recorded"
 
-## OUTPUT STRUCTURE
+## OUTPUT STRUCTURE (with quick flywheel hooks)
 
 Execute this workflow in 5 sequential steps, reporting progress after each:
 
@@ -96,7 +96,7 @@ scripts/bash/create-phr.sh \
 
 Parse the JSON output to get: `id`, `path`, `context`, `stage`, `feature`
 
-## Step 4: Fill ALL Template Placeholders
+## Step 4: Fill ALL Template Placeholders (Analyze→Measure)
 
 Read the file at `path` from JSON output. Replace ALL {{PLACEHOLDERS}}:
 
@@ -127,6 +127,8 @@ Read the file at `path` from JSON output. Replace ALL {{PLACEHOLDERS}}:
 - `{{NEXT_PROMPTS}}` → Suggested next steps or "none"
 - `{{REFLECTION_NOTE}}` → One key insight
 
+Add evaluation notes (short): failure modes observed; next experiment to improve prompt quality.
+
 **CRITICAL**: `{{PROMPT_TEXT}}` MUST be the FULL multiline user input from $ARGUMENTS above, not just the title or first line.
 
 ## Step 5: Report Completion
@@ -143,6 +145,11 @@ Stage: {stage}
 Feature: {feature or "none"}
 Files modified: {count}
 Tests involved: {count}
+
+Acceptance Criteria (PASS only if all true)
+- Full prompt preserved verbatim (no truncation)
+- Stage and routing determined correctly
+- Metadata fields populated; missing values noted explicitly
 ```
 
 ## ERROR HANDLING

--- a/templates/commands/phr.md
+++ b/templates/commands/phr.md
@@ -127,7 +127,9 @@ Read the file at `path` from JSON output. Replace ALL {{PLACEHOLDERS}}:
 - `{{NEXT_PROMPTS}}` → Suggested next steps or "none"
 - `{{REFLECTION_NOTE}}` → One key insight
 
-Add evaluation notes (short): failure modes observed; next experiment to improve prompt quality.
+Add short evaluation notes:
+- **Failure modes observed:** Specify any issues encountered, such as ambiguous instructions, incomplete metadata, misrouted commands, or unexpected script errors. Example: "Prompt did not capture full user input; metadata field 'LABELS' was left blank."
+- **Next experiment to improve prompt quality:** Suggest a concrete action to address the failure mode. Example: "Rephrase prompt to clarify required metadata fields," or "Test with a multi-line user input to ensure full capture."
 
 **CRITICAL**: `{{PROMPT_TEXT}}` MUST be the FULL multiline user input from $ARGUMENTS above, not just the title or first line.
 

--- a/templates/phr-template.prompt.md
+++ b/templates/phr-template.prompt.md
@@ -36,3 +36,10 @@ tests:
 - 📁 Files: {{FILES_SUMMARY}}
 - 🔁 Next prompts: {{NEXT_PROMPTS}}
 - 🧠 Reflection: {{REFLECTION_NOTE}}
+
+## Evaluation notes (flywheel)
+
+- Failure modes observed: {{FAILURE_MODES}}
+- Graders run and results (PASS/FAIL): {{GRADER_RESULTS}}
+- Prompt variant (if applicable): {{PROMPT_VARIANT_ID}}
+- Next experiment (smallest change to try): {{NEXT_EXPERIMENT}}


### PR DESCRIPTION
## Summary
- Consolidate system prompt header in AGENTS.md (intro, surface, success metrics).
- Align with protocol-templates/AGENTS.md Core Guarantees, documentation hooks, execution contract.
- Clarify propagation of agent rules into agent-specific files during init.
- Prepare follow-up improvements to command rules and template prompts.

## Why
- Unify authoritative system instructions across repo and templates.
- Ensure each agent gets the right rules file in its native location (Cursor, Gemini, Qwen, etc.).
- Improve clarity and enforceability of prompts (PHR/ADR, graders) for SDD workflows.

## Changes
- AGENTS.md: Reworked opening prompt; integration guides unchanged.
- src/specifyplus_cli/__init__.py: Confirms rule propagation into agent-specific files during specify init.
- memory/command-rules.md: Canonical implicit PHR and ADR suggestion behavior (reference only in this PR).
- templates/adr-template.md, templates/phr-template.prompt.md: Identified improvements (planned next).

- Append concise command rules footers across templates using memory/command-rules.md.
- Harden agent-specific rule placement for Windsurf/Copilot and consistent paths.
- Tune adr-template.md and phr-template.prompt.md with explicit graders and acceptance checks.

## Acceptance Criteria
- [x] AGENTS.md header consolidated and aligned.
- [x] Agent rule propagation behavior documented and supported by existing init code.
- [x] No unrelated refactors; smallest viable change.

## Risks
- Low (docs only); init rule propagation already present.

## References
- protocol-templates/AGENTS.md
- memory/command-rules.md
- templates/adr-template.md
- templates/phr-template.prompt.md